### PR TITLE
Add ability to read roadmap items from csv file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
  "wasm-bindgen",
  "winapi",
@@ -559,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07b0a1390e01c0fc35ebb26b28ced33c9a3808f7f9fbe94d3cc01e233bfeed5"
+checksum = "32ad5bf234c7d3ad1042e5252b7eddb2c4669ee23f32c7dd0e9b7705f07ef591"
 dependencies = [
  "idna 0.2.3",
  "lazy_static",
@@ -575,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7ed5e8cf2b6bdd64a6c4ce851da25388a89327b17b88424ceced6bd5017923"
+checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
 dependencies = [
  "if_chain",
  "lazy_static",
@@ -591,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "validator_types"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ddf34293296847abfc1493b15c6e2f5d3cd19f57ad7d22673bf4c6278da329"
+checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
 dependencies = [
  "proc-macro2",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 rand = "0.8.5"
 csv = "1.1"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -66,15 +66,28 @@ have to build it from source. Kapacitet is built with Rust, so
 please refer to [this](https://www.rust-lang.org/tools/install) on how
 to get started.
 
-Kapacitet lets you add contributors directly from the command line 
-or from a CSV file. The contributors CSV should look like this:
+Kapacitet lets you add contributors and roadmap items directly from 
+the command line or from CSV files. 
+
+The contributors CSV should look like this:
 
 ```
 name,seniority
 Contributor Uno,5
 ```
 
-with the seniority being an integer between 1 and 5.
+with `seniority` being an integer between 1 and 5.
+
+The roadmap CSV should look like this:
+
+```
+name,estimated_complexity,estimated_value,start_date,target_date
+MVP,4,5,2022-06-01,2022-11-01
+```
+
+with `estimated_complexity` and `estimated_value` being integers 
+between 1 and 5 and `start_date` and `target_date` following the 
+date format `YYYY-mm-dd`.
 
 ## TODO
 


### PR DESCRIPTION
This PR adds the ability to provide a CSV file containing all roadmap items, as an alternative to inputting everything via stdin. The CSV file should follow the format (including the header row):

```
name,estimated_complexity,estimated_value,start_date,target_date
MVP,4,5,2022-06-01,2022-11-01
```

with `estimated_complexity` and `estimated_value` being integers between 1 and 5 and `start_date` and `target_date` following the date format `YYYY-mm-dd`. 

The input is deserialized and validated using the crates [csv](https://docs.rs/csv/latest/csv/) with [serde](https://docs.rs/serde/latest/serde/), and [validator](https://docs.rs/validator/latest/validator/).